### PR TITLE
refactor(kv-client): prioritize environment variable for KV base URL …

### DIFF
--- a/node-functions/send/[[key]].ts
+++ b/node-functions/send/[[key]].ts
@@ -38,18 +38,18 @@ app.use(async (ctx, next) => {
 app.use(bodyParser());
 
 // 设置 KV baseUrl
-// Edge Functions 和 Node Functions 同源，但本地开发时端口不同
+// 优先使用环境变量 KV_BASE_URL，生产环境留空使用同源
 app.use(async (ctx, next) => {
-  const protocol = ctx.get('x-forwarded-proto') || ctx.protocol || 'http';
-  let host = ctx.get('host') || 'localhost:8088';
+  const kvBaseUrl = process.env.KV_BASE_URL;
   
-  // 本地开发时，Node Functions 内部端口是 9000，需要改为 8088
-  if (host.includes(':9000')) {
-    host = host.replace(':9000', ':8088');
+  if (kvBaseUrl) {
+    setKVBaseUrl(kvBaseUrl);
+  } else {
+    const protocol = ctx.get('x-forwarded-proto') || ctx.protocol || 'http';
+    const host = ctx.get('host') || 'localhost:8088';
+    setKVBaseUrl(`${protocol}://${host}`);
   }
   
-  const baseUrl = `${protocol}://${host}`;
-  setKVBaseUrl(baseUrl);
   await next();
 });
 

--- a/node-functions/shared/kv-client.ts
+++ b/node-functions/shared/kv-client.ts
@@ -6,8 +6,7 @@
  * Node Functions 无法直接访问 EdgeOne KV，需要通过 Edge Functions 代理
  * Edge Functions 位于 edge-functions/api/kv/ 目录
  * 
- * Edge Functions 和 Node Functions 同源，使用相对路径即可
- * 本地开发时，EdgeOne CLI 会同时启动 Edge Functions 和 Node Functions
+ * 优先使用环境变量 KV_BASE_URL，生产环境留空使用同源请求
  */
 
 // Store for dynamic base URL (set from request context)
@@ -23,10 +22,10 @@ export function setKVBaseUrl(url: string): void {
 
 /**
  * Get the base URL for KV API
- * 使用请求上下文中的 baseUrl，确保同源访问
+ * 优先使用环境变量 KV_BASE_URL，其次使用动态设置的 baseUrl
  */
 function getBaseUrl(): string {
-  return dynamicBaseUrl || '';
+  return process.env.KV_BASE_URL || dynamicBaseUrl || '';
 }
 
 /**

--- a/node-functions/v1/[[default]].ts
+++ b/node-functions/v1/[[default]].ts
@@ -33,19 +33,20 @@ import { setKVBaseUrl } from '../shared/kv-client.js';
 const app = new Koa();
 
 // 设置 KV baseUrl 的中间件
-// Edge Functions 和 Node Functions 同源，但本地开发时端口不同
-// Node Functions 内部运行在 9000 端口，需要请求 8088 端口的 Edge Functions
+// 优先使用环境变量 KV_BASE_URL（本地开发时指向远程 Edge Functions）
+// 生产环境留空则使用同源请求
 app.use(async (ctx, next) => {
-  const protocol = ctx.get('x-forwarded-proto') || ctx.protocol || 'http';
-  let host = ctx.get('host') || 'localhost:8088';
+  const kvBaseUrl = process.env.KV_BASE_URL;
   
-  // 本地开发时，Node Functions 内部端口是 9000，需要改为 8088
-  if (host.includes(':9000')) {
-    host = host.replace(':9000', ':8088');
+  if (kvBaseUrl) {
+    setKVBaseUrl(kvBaseUrl);
+  } else {
+    // 生产环境：使用同源请求
+    const protocol = ctx.get('x-forwarded-proto') || ctx.protocol || 'http';
+    const host = ctx.get('host') || 'localhost:8088';
+    setKVBaseUrl(`${protocol}://${host}`);
   }
   
-  const baseUrl = `${protocol}://${host}`;
-  setKVBaseUrl(baseUrl);
   await next();
 });
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "dev": "nuxt dev",
     "dev:edgeone": "edgeone pages dev",
-    "build": "yarn generate:openapi && nuxt generate",
+    "build": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
     "test": "vitest run",


### PR DESCRIPTION
…configuration

- Update KV client to prioritize KV_BASE_URL environment variable over dynamic base URL
- Simplify KV base URL middleware in send and v1 endpoints to check environment variable first
- Fall back to same-origin requests in production when KV_BASE_URL is not set
- Remove port translation logic for local development (now handled via environment variable)
- Update documentation comments to reflect new configuration approach
- Remove unnecessary OpenAPI generation from build script
- Enables flexible KV endpoint configuration for different deployment environments