### PR TITLE
chore: update build key and improve request logging

### DIFF
--- a/edge-functions/api/kv/apps.js
+++ b/edge-functions/api/kv/apps.js
@@ -3,7 +3,7 @@
 // KV Binding: APPS_KV (configured in EdgeOne Pages)
 
 // BUILD_KEY 在构建时被替换为实际值
-const BUILD_KEY = '0ad7edb9be264271c0a3351e645e320ebc52f8642871b5939e14b05152d6ef26';
+const BUILD_KEY = '42eedfba5fbfca18c4dbb30be198fe9262418067c1ba6788d003a6920108f49c';
 
 /**
  * 验证内部 API 密钥

--- a/edge-functions/api/kv/channels.js
+++ b/edge-functions/api/kv/channels.js
@@ -3,7 +3,7 @@
 // KV Binding: CHANNELS_KV (configured in EdgeOne Pages)
 
 // BUILD_KEY 在构建时被替换为实际值
-const BUILD_KEY = '0ad7edb9be264271c0a3351e645e320ebc52f8642871b5939e14b05152d6ef26';
+const BUILD_KEY = '42eedfba5fbfca18c4dbb30be198fe9262418067c1ba6788d003a6920108f49c';
 
 /**
  * 验证内部 API 密钥

--- a/edge-functions/api/kv/config.js
+++ b/edge-functions/api/kv/config.js
@@ -3,7 +3,7 @@
 // KV Binding: CONFIG_KV (configured in EdgeOne Pages)
 
 // BUILD_KEY 在构建时被替换为实际值
-const BUILD_KEY = '0ad7edb9be264271c0a3351e645e320ebc52f8642871b5939e14b05152d6ef26';
+const BUILD_KEY = '42eedfba5fbfca18c4dbb30be198fe9262418067c1ba6788d003a6920108f49c';
 
 /**
  * 验证内部 API 密钥

--- a/edge-functions/api/kv/messages.js
+++ b/edge-functions/api/kv/messages.js
@@ -3,7 +3,7 @@
 // KV Binding: MESSAGES_KV (configured in EdgeOne Pages)
 
 // BUILD_KEY 在构建时被替换为实际值
-const BUILD_KEY = '0ad7edb9be264271c0a3351e645e320ebc52f8642871b5939e14b05152d6ef26';
+const BUILD_KEY = '42eedfba5fbfca18c4dbb30be198fe9262418067c1ba6788d003a6920108f49c';
 
 /**
  * 验证内部 API 密钥

--- a/edge-functions/api/kv/openids.js
+++ b/edge-functions/api/kv/openids.js
@@ -3,7 +3,7 @@
 // KV Binding: OPENIDS_KV (configured in EdgeOne Pages)
 
 // BUILD_KEY 在构建时被替换为实际值
-const BUILD_KEY = '0ad7edb9be264271c0a3351e645e320ebc52f8642871b5939e14b05152d6ef26';
+const BUILD_KEY = '42eedfba5fbfca18c4dbb30be198fe9262418067c1ba6788d003a6920108f49c';
 
 /**
  * 验证内部 API 密钥

--- a/node-functions/send/[[key]].ts
+++ b/node-functions/send/[[key]].ts
@@ -56,6 +56,9 @@ app.use(async (ctx, next) => {
 // 主处理逻辑
 app.use(async (ctx) => {
   const pathname = ctx.path;
+  console.log('\x1b[36m[Send]\x1b[0m Request path:', pathname);
+  console.log('\x1b[36m[Send]\x1b[0m Full URL:', ctx.url);
+  console.log('\x1b[36m[Send]\x1b[0m Method:', ctx.method);
 
   // 只允许 GET 和 POST
   if (ctx.method !== 'GET' && ctx.method !== 'POST') {
@@ -70,6 +73,8 @@ app.use(async (ctx) => {
 
   // 从 URL 提取 App Key
   const appKey = extractAppKey(pathname);
+  console.log('\x1b[36m[Send]\x1b[0m Extracted appKey:', appKey);
+  
   if (!appKey) {
     ctx.status = 400;
     ctx.body = {
@@ -122,7 +127,7 @@ app.use(async (ctx) => {
 
 /**
  * 从 URL 路径提取 App Key
- * 支持: /APKxxx.send 或 /send/APKxxx
+ * 支持: /APKxxx.send 或 /send/APKxxx 或 /APKxxx (EdgeOne catch-all)
  */
 function extractAppKey(pathname: string): string | null {
   // Pattern: /:appKey.send
@@ -135,6 +140,13 @@ function extractAppKey(pathname: string): string | null {
   const slashMatch = pathname.match(/\/send\/([^/]+)/);
   if (slashMatch) {
     return slashMatch[1];
+  }
+
+  // Pattern: /:appKey (EdgeOne catch-all route, path is just the key)
+  // 当 EdgeOne 使用 [[key]].ts 时，ctx.path 可能只是 /APKxxx
+  const directMatch = pathname.match(/^\/([A-Za-z0-9_-]+)$/);
+  if (directMatch && directMatch[1].startsWith('APK')) {
+    return directMatch[1];
   }
 
   return null;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['**/*.test.ts'],
+    exclude: ['**/node_modules/**', '**/dist/**'],
     globals: true,
     testTimeout: 30000,
   },


### PR DESCRIPTION
- Update BUILD_KEY across all KV edge functions (apps, channels, config, messages, openids)
- Add detailed request logging to send function with colored output for debugging
- Log request path, full URL, and HTTP method for better traceability
- Log extracted appKey value to aid in troubleshooting routing issues
- Enhance extractAppKey function to support EdgeOne catch-all route pattern
- Add support for direct appKey extraction from pathname (/:appKey format)
- Update extractAppKey documentation to reflect new route pattern support
- Configure vitest to exclude node_modules and dist directories from test discovery