### PR TITLE
chore: update build key and improve WeChat message handling

### DIFF
--- a/edge-functions/api/kv/apps.js
+++ b/edge-functions/api/kv/apps.js
@@ -3,7 +3,7 @@
 // KV Binding: APPS_KV (configured in EdgeOne Pages)
 
 // BUILD_KEY 在构建时被替换为实际值
-const BUILD_KEY = '42eedfba5fbfca18c4dbb30be198fe9262418067c1ba6788d003a6920108f49c';
+const BUILD_KEY = 'e2a9b03440135ba42629a162500834c54048024f1e400a4aa9ce703ac123ff9b';
 
 /**
  * 验证内部 API 密钥

--- a/edge-functions/api/kv/channels.js
+++ b/edge-functions/api/kv/channels.js
@@ -3,7 +3,7 @@
 // KV Binding: CHANNELS_KV (configured in EdgeOne Pages)
 
 // BUILD_KEY 在构建时被替换为实际值
-const BUILD_KEY = '42eedfba5fbfca18c4dbb30be198fe9262418067c1ba6788d003a6920108f49c';
+const BUILD_KEY = 'e2a9b03440135ba42629a162500834c54048024f1e400a4aa9ce703ac123ff9b';
 
 /**
  * 验证内部 API 密钥

--- a/edge-functions/api/kv/config.js
+++ b/edge-functions/api/kv/config.js
@@ -3,7 +3,7 @@
 // KV Binding: CONFIG_KV (configured in EdgeOne Pages)
 
 // BUILD_KEY 在构建时被替换为实际值
-const BUILD_KEY = '42eedfba5fbfca18c4dbb30be198fe9262418067c1ba6788d003a6920108f49c';
+const BUILD_KEY = 'e2a9b03440135ba42629a162500834c54048024f1e400a4aa9ce703ac123ff9b';
 
 /**
  * 验证内部 API 密钥

--- a/edge-functions/api/kv/messages.js
+++ b/edge-functions/api/kv/messages.js
@@ -3,7 +3,7 @@
 // KV Binding: MESSAGES_KV (configured in EdgeOne Pages)
 
 // BUILD_KEY 在构建时被替换为实际值
-const BUILD_KEY = '42eedfba5fbfca18c4dbb30be198fe9262418067c1ba6788d003a6920108f49c';
+const BUILD_KEY = 'e2a9b03440135ba42629a162500834c54048024f1e400a4aa9ce703ac123ff9b';
 
 /**
  * 验证内部 API 密钥

--- a/edge-functions/api/kv/openids.js
+++ b/edge-functions/api/kv/openids.js
@@ -3,7 +3,7 @@
 // KV Binding: OPENIDS_KV (configured in EdgeOne Pages)
 
 // BUILD_KEY 在构建时被替换为实际值
-const BUILD_KEY = '42eedfba5fbfca18c4dbb30be198fe9262418067c1ba6788d003a6920108f49c';
+const BUILD_KEY = 'e2a9b03440135ba42629a162500834c54048024f1e400a4aa9ce703ac123ff9b';
 
 /**
  * 验证内部 API 密钥


### PR DESCRIPTION
- Update BUILD_KEY across all KV API modules (apps, channels, config, messages, openids)
- Remove redundant comments in WeChat message subscription handling
- Add clarifying comment for unsubscribe event (no reply)
- Fix condition check for SCAN event to include fromUser validation
- Add comprehensive handling for other event types with message logging
- Improve text message reply with fallback to '收到' when no reply content
- Add support for non-text message types (images, voice, video) with logging
- Ensure reply is always generated before sending response
- Add console logging for successful XML replies and error cases
- Update handleScanBind to return welcome message for invalid binding codes instead of empty string