### PR TITLE
chore: update build key and refactor WeChat message handling

### DIFF
--- a/edge-functions/api/kv/apps.js
+++ b/edge-functions/api/kv/apps.js
@@ -3,7 +3,7 @@
 // KV Binding: APPS_KV (configured in EdgeOne Pages)
 
 // BUILD_KEY 在构建时被替换为实际值
-const BUILD_KEY = 'e2a9b03440135ba42629a162500834c54048024f1e400a4aa9ce703ac123ff9b';
+const BUILD_KEY = 'd277463d2aed1e352acee812ac123e3da605314b1f8e6a219d092f25388d3710';
 
 /**
  * 验证内部 API 密钥

--- a/edge-functions/api/kv/channels.js
+++ b/edge-functions/api/kv/channels.js
@@ -3,7 +3,7 @@
 // KV Binding: CHANNELS_KV (configured in EdgeOne Pages)
 
 // BUILD_KEY 在构建时被替换为实际值
-const BUILD_KEY = 'e2a9b03440135ba42629a162500834c54048024f1e400a4aa9ce703ac123ff9b';
+const BUILD_KEY = 'd277463d2aed1e352acee812ac123e3da605314b1f8e6a219d092f25388d3710';
 
 /**
  * 验证内部 API 密钥

--- a/edge-functions/api/kv/config.js
+++ b/edge-functions/api/kv/config.js
@@ -3,7 +3,7 @@
 // KV Binding: CONFIG_KV (configured in EdgeOne Pages)
 
 // BUILD_KEY 在构建时被替换为实际值
-const BUILD_KEY = 'e2a9b03440135ba42629a162500834c54048024f1e400a4aa9ce703ac123ff9b';
+const BUILD_KEY = 'd277463d2aed1e352acee812ac123e3da605314b1f8e6a219d092f25388d3710';
 
 /**
  * 验证内部 API 密钥

--- a/edge-functions/api/kv/messages.js
+++ b/edge-functions/api/kv/messages.js
@@ -3,7 +3,7 @@
 // KV Binding: MESSAGES_KV (configured in EdgeOne Pages)
 
 // BUILD_KEY 在构建时被替换为实际值
-const BUILD_KEY = 'e2a9b03440135ba42629a162500834c54048024f1e400a4aa9ce703ac123ff9b';
+const BUILD_KEY = 'd277463d2aed1e352acee812ac123e3da605314b1f8e6a219d092f25388d3710';
 
 /**
  * 验证内部 API 密钥

--- a/edge-functions/api/kv/openids.js
+++ b/edge-functions/api/kv/openids.js
@@ -3,7 +3,7 @@
 // KV Binding: OPENIDS_KV (configured in EdgeOne Pages)
 
 // BUILD_KEY 在构建时被替换为实际值
-const BUILD_KEY = 'e2a9b03440135ba42629a162500834c54048024f1e400a4aa9ce703ac123ff9b';
+const BUILD_KEY = 'd277463d2aed1e352acee812ac123e3da605314b1f8e6a219d092f25388d3710';
 
 /**
  * 验证内部 API 密钥

--- a/node-functions/middleware/response-wrapper.ts
+++ b/node-functions/middleware/response-wrapper.ts
@@ -23,7 +23,8 @@ export async function responseWrapper(ctx: Context, next: Next): Promise<void> {
   }
 
   // XML 响应不包装（微信消息回复）
-  if (ctx.type === 'application/xml' || ctx.type === 'text/xml') {
+  const contentType = ctx.type || ctx.response.get('Content-Type') || '';
+  if (contentType.includes('xml')) {
     return;
   }
 

--- a/node-functions/routes/wechat-msg.ts
+++ b/node-functions/routes/wechat-msg.ts
@@ -235,7 +235,8 @@ async function handleWeChatMessage(ctx: AppContext, channelId?: string) {
 
   if (toUser && fromUser) {
     ctx.type = 'application/xml';
-    ctx.body = buildTextReply(toUser, fromUser, replyContent);
+    // 回复时交换发送者和接收者：ToUserName 是用户，FromUserName 是公众号
+    ctx.body = buildTextReply(fromUser, toUser, replyContent);
     console.log('\x1b[32m[WeChat]\x1b[0m Reply XML sent');
   } else {
     // 无法构建回复时返回 success

--- a/node-functions/services/push.service.ts
+++ b/node-functions/services/push.service.ts
@@ -12,23 +12,10 @@ import { appService } from './app.service.js';
 import { openidService } from './openid.service.js';
 import { channelService } from './channel.service.js';
 import { messageService } from './message.service.js';
-import { channelsKV } from '../shared/kv-client.js';
+import { wechatService } from './wechat.service.js';
 import { generatePushId, now } from '../shared/utils.js';
-import type { Channel, PushResult, PushMessageInput, DeliveryResult, Message } from '../types/index.js';
-import { PushModes, MessageTypes, KVKeys } from '../types/index.js';
-
-interface TokenCache {
-  accessToken: string;
-  expiresAt: number;
-}
-
-interface WeChatResponse {
-  errcode?: number;
-  errmsg?: string;
-  access_token?: string;
-  expires_in?: number;
-  msgid?: number;
-}
+import type { PushResult, PushMessageInput, DeliveryResult, Message } from '../types/index.js';
+import { PushModes, MessageTypes } from '../types/index.js';
 
 class PushService {
   /**
@@ -81,22 +68,6 @@ class PushService {
       targetOpenIds = [openIds[0]];
     }
 
-    // 获取 Access Token
-    const accessToken = await this.getAccessToken(channel);
-    if (!accessToken) {
-      return {
-        pushId,
-        total: targetOpenIds.length,
-        success: 0,
-        failed: targetOpenIds.length,
-        results: targetOpenIds.map((oid) => ({
-          openId: oid.openId,
-          success: false,
-          error: 'Failed to get access token',
-        })),
-      };
-    }
-
     // 发送消息
     const results: DeliveryResult[] = [];
     let successCount = 0;
@@ -105,18 +76,29 @@ class PushService {
     for (const openIdRecord of targetOpenIds) {
       try {
         let result: { success: boolean; msgId?: string; error?: string };
+        
         if (app.messageType === MessageTypes.TEMPLATE && app.templateId) {
-          result = await this.sendTemplateMessage(
-            accessToken,
+          // 发送模板消息
+          const templateData = {
+            first: { value: message.title || '' },
+            keyword1: { value: message.desp || '' },
+            remark: { value: '' },
+          };
+          result = await wechatService.sendTemplateMessage(
+            channel,
             openIdRecord.openId,
             app.templateId,
-            message
+            templateData
           );
         } else {
-          result = await this.sendTextMessage(
-            accessToken,
+          // 发送客服消息
+          const content = message.desp
+            ? `${message.title}\n\n${message.desp}`
+            : message.title;
+          result = await wechatService.sendCustomMessage(
+            channel,
             openIdRecord.openId,
-            message
+            content
           );
         }
 
@@ -163,131 +145,6 @@ class PushService {
       failed: failedCount,
       results,
     };
-  }
-
-  /**
-   * 获取微信 Access Token（带缓存）
-   */
-  async getAccessToken(channel: Channel): Promise<string | null> {
-    const cacheKey = KVKeys.WECHAT_TOKEN(channel.config.appId);
-
-    // 尝试从缓存获取
-    const cached = await channelsKV.get<TokenCache>(cacheKey);
-    if (cached?.accessToken && cached?.expiresAt > Date.now()) {
-      return cached.accessToken;
-    }
-
-    // 请求新的 Access Token
-    try {
-      const url = `https://api.weixin.qq.com/cgi-bin/token?grant_type=client_credential&appid=${channel.config.appId}&secret=${channel.config.appSecret}`;
-      const res = await fetch(url);
-      const data = (await res.json()) as WeChatResponse;
-
-      if (data.errcode) {
-        console.error('Failed to get access token:', data);
-        return null;
-      }
-
-      if (!data.access_token || !data.expires_in) {
-        return null;
-      }
-
-      const tokenData: TokenCache = {
-        accessToken: data.access_token,
-        expiresAt: Date.now() + (data.expires_in - 300) * 1000, // 5 分钟缓冲
-      };
-
-      // 缓存到 KV（TTL 略小于 2 小时）
-      await channelsKV.put(cacheKey, tokenData, 7000);
-
-      return data.access_token;
-    } catch (error) {
-      console.error('Error fetching access token:', error);
-      return null;
-    }
-  }
-
-  /**
-   * 发送模板消息
-   */
-  async sendTemplateMessage(
-    accessToken: string,
-    openId: string,
-    templateId: string,
-    message: PushMessageInput
-  ): Promise<{ success: boolean; msgId?: string; error?: string }> {
-    try {
-      const url = `https://api.weixin.qq.com/cgi-bin/message/template/send?access_token=${accessToken}`;
-
-      // 构建模板消息数据
-      const templateData = {
-        first: { value: message.title || '' },
-        keyword1: { value: message.desp || '' },
-        remark: { value: '' },
-      };
-
-      const body = {
-        touser: openId,
-        template_id: templateId,
-        data: templateData,
-      };
-
-      const res = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      });
-
-      const data = (await res.json()) as WeChatResponse;
-
-      if (data.errcode === 0) {
-        return { success: true, msgId: String(data.msgid) };
-      } else {
-        return { success: false, error: `WeChat API error: ${data.errcode} - ${data.errmsg}` };
-      }
-    } catch (error) {
-      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
-    }
-  }
-
-  /**
-   * 发送客服文本消息
-   */
-  async sendTextMessage(
-    accessToken: string,
-    openId: string,
-    message: PushMessageInput
-  ): Promise<{ success: boolean; msgId?: string; error?: string }> {
-    try {
-      const url = `https://api.weixin.qq.com/cgi-bin/message/custom/send?access_token=${accessToken}`;
-
-      // 构建文本内容
-      const content = message.desp
-        ? `${message.title}\n\n${message.desp}`
-        : message.title;
-
-      const body = {
-        touser: openId,
-        msgtype: 'text',
-        text: { content },
-      };
-
-      const res = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      });
-
-      const data = (await res.json()) as WeChatResponse;
-
-      if (data.errcode === 0) {
-        return { success: true, msgId: String(data.msgid || '') };
-      } else {
-        return { success: false, error: `WeChat API error: ${data.errcode} - ${data.errmsg}` };
-      }
-    } catch (error) {
-      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
-    }
   }
 }
 


### PR DESCRIPTION
- Update BUILD_KEY across all KV API endpoints (apps, channels, config, messages, openids)
- Fix XML response detection in response wrapper middleware to check Content-Type header
- Correct WeChat message reply sender/receiver mapping (swap toUser and fromUser)
- Refactor push service to delegate WeChat API calls to wechat service
- Remove token caching logic from push service (moved to wechat service)
- Simplify message sending with direct wechat service integration for template and custom messages
- Remove unused KV and type imports from push service
- Improve code organization by centralizing WeChat API operations in dedicated service