### PR TITLE
feat(demo-apps): add quick start guide and enhance app configuration …

### DIFF
--- a/app/composables/useDemoApps.test.ts
+++ b/app/composables/useDemoApps.test.ts
@@ -1,0 +1,42 @@
+/**
+ * useDemoApps Composable 测试
+ * Feature: demo-mode
+ * 
+ * 测试体验应用 API 客户端的响应处理
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('useDemoApps Composable', () => {
+  describe('Response Handling', () => {
+    it('should extract data from wrapped API response', () => {
+      // 模拟后端返回的包装响应
+      const wrappedResponse = {
+        code: 0,
+        message: 'success',
+        data: [
+          { id: 'app_1', name: 'Test App 1' },
+          { id: 'app_2', name: 'Test App 2' },
+        ],
+      };
+
+      // 验证我们能正确提取 data 字段
+      expect(wrappedResponse.data).toHaveLength(2);
+      expect(wrappedResponse.data[0].id).toBe('app_1');
+    });
+
+    it('should handle nested data structure', () => {
+      // 模拟 responseWrapper 中间件的行为
+      const originalData = { id: 'app_1', name: 'Test' };
+      const wrappedData = {
+        code: 0,
+        message: 'success',
+        data: originalData,
+      };
+
+      // 验证数据嵌套
+      expect(wrappedData.data).toEqual(originalData);
+      expect(wrappedData.data.id).toBe('app_1');
+    });
+  });
+});

--- a/app/composables/useDemoApps.ts
+++ b/app/composables/useDemoApps.ts
@@ -37,7 +37,7 @@ export function useDemoApps() {
     data?: any
   ): Promise<DemoApiResponse<T>> {
     try {
-      const response = await $fetch<T>(`${baseURL}${url}`, {
+      const response = await $fetch<any>(`${baseURL}${url}`, {
         method,
         body: data,
         headers: {
@@ -45,9 +45,19 @@ export function useDemoApps() {
         },
       });
 
+      // 后端使用 responseWrapper 中间件，返回格式为 { code, message, data }
+      // 我们需要提取嵌套的 data 字段
+      if (response && typeof response === 'object' && 'data' in response) {
+        return {
+          success: true,
+          data: response.data as T,
+        };
+      }
+
+      // 如果没有包装，直接返回
       return {
         success: true,
-        data: response,
+        data: response as T,
       };
     } catch (error: any) {
       return {

--- a/edge-functions/api/kv/apps.js
+++ b/edge-functions/api/kv/apps.js
@@ -3,7 +3,7 @@
 // KV Binding: APPS_KV (configured in EdgeOne Pages)
 
 // BUILD_KEY 在构建时被替换为实际值
-const BUILD_KEY = 'e10469d66c1f667b0a9ad0ecb6973f3f8764eff9ebc536dd26124863fdb4c5ed';
+const BUILD_KEY = 'b1c3c5436a24a36cf6a4190a6b0a049bc554017f31f2c31be65430202d10c5e7';
 
 /**
  * 验证内部 API 密钥

--- a/edge-functions/api/kv/channels.js
+++ b/edge-functions/api/kv/channels.js
@@ -3,7 +3,7 @@
 // KV Binding: CHANNELS_KV (configured in EdgeOne Pages)
 
 // BUILD_KEY 在构建时被替换为实际值
-const BUILD_KEY = 'e10469d66c1f667b0a9ad0ecb6973f3f8764eff9ebc536dd26124863fdb4c5ed';
+const BUILD_KEY = 'b1c3c5436a24a36cf6a4190a6b0a049bc554017f31f2c31be65430202d10c5e7';
 
 /**
  * 验证内部 API 密钥

--- a/edge-functions/api/kv/config.js
+++ b/edge-functions/api/kv/config.js
@@ -3,7 +3,7 @@
 // KV Binding: CONFIG_KV (configured in EdgeOne Pages)
 
 // BUILD_KEY 在构建时被替换为实际值
-const BUILD_KEY = 'e10469d66c1f667b0a9ad0ecb6973f3f8764eff9ebc536dd26124863fdb4c5ed';
+const BUILD_KEY = 'b1c3c5436a24a36cf6a4190a6b0a049bc554017f31f2c31be65430202d10c5e7';
 
 /**
  * 验证内部 API 密钥

--- a/edge-functions/api/kv/messages.js
+++ b/edge-functions/api/kv/messages.js
@@ -3,7 +3,7 @@
 // KV Binding: MESSAGES_KV (configured in EdgeOne Pages)
 
 // BUILD_KEY 在构建时被替换为实际值
-const BUILD_KEY = 'e10469d66c1f667b0a9ad0ecb6973f3f8764eff9ebc536dd26124863fdb4c5ed';
+const BUILD_KEY = 'b1c3c5436a24a36cf6a4190a6b0a049bc554017f31f2c31be65430202d10c5e7';
 
 /**
  * 验证内部 API 密钥

--- a/edge-functions/api/kv/openids.js
+++ b/edge-functions/api/kv/openids.js
@@ -3,7 +3,7 @@
 // KV Binding: OPENIDS_KV (configured in EdgeOne Pages)
 
 // BUILD_KEY 在构建时被替换为实际值
-const BUILD_KEY = 'e10469d66c1f667b0a9ad0ecb6973f3f8764eff9ebc536dd26124863fdb4c5ed';
+const BUILD_KEY = 'b1c3c5436a24a36cf6a4190a6b0a049bc554017f31f2c31be65430202d10c5e7';
 
 /**
  * 验证内部 API 密钥


### PR DESCRIPTION
…display

- Add comprehensive quick start guide with 3-step onboarding instructions
- Display push mode (single/subscription) and message type (template/text) badges for each app
- Add webhook usage examples with tabbed interface for different integration methods
- Fix webhook URL generation to use app.key instead of app.id
- Add useDemoApps.test.ts test file for composable testing
- Update KV storage handlers for apps, channels, config, messages, and openids
- Update demo-apps route to support new configuration options
- Improve UX with informational callouts and configuration explanations for demo mode users