### PR TITLE
refactor(middleware): extract KV base URL logic into reusable middleware

### DIFF
--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -40,7 +40,31 @@ edgeone pages dev
 
 所有服务运行在 `http://localhost:8088`
 
-### 3. KV 存储
+### 3. 配置环境变量（可选）
+
+复制 `.env.example` 为 `.env.local`：
+
+```bash
+cp .env.example .env.local
+```
+
+#### KV_BASE_URL 配置说明
+
+- **本地开发**：如果需要连接远程 KV，设置为远程地址
+  ```bash
+  KV_BASE_URL=https://your-project.edgeone.app
+  ```
+
+- **生产环境**：留空或不设置，系统会自动从请求头中提取当前域名
+  ```bash
+  # KV_BASE_URL=
+  ```
+
+系统会按以下优先级确定 KV API 地址：
+1. 环境变量 `KV_BASE_URL`（如果设置）
+2. 自动检测当前请求的域名（推荐生产环境使用）
+
+### 4. KV 存储
 
 #### 本地模拟 KV
 `edgeone pages dev` 会自动模拟 KV 存储，数据保存在本地，无需额外配置。

--- a/node-functions/middleware/index.ts
+++ b/node-functions/middleware/index.ts
@@ -7,3 +7,4 @@ export { responseWrapper, success, paginated } from './response-wrapper.js';
 export { adminAuth, hasValidAdminToken } from './admin-auth.js';
 export { cors } from './cors.js';
 export { xmlBody } from './xml-body.js';
+export { kvBaseUrlMiddleware, extractBaseUrl } from './kv-base-url.js';

--- a/node-functions/middleware/kv-base-url.ts
+++ b/node-functions/middleware/kv-base-url.ts
@@ -1,0 +1,74 @@
+/**
+ * KV Base URL 中间件
+ * 
+ * 自动从请求上下文中提取域名，设置 KV API 的 baseUrl
+ * 优先使用环境变量 KV_BASE_URL，否则自动检测当前域名
+ * 
+ * EdgeOne 环境说明：
+ * - EdgeOne 默认携带 X-Forwarded-Proto 和 X-Forwarded-For 头
+ * - 协议通过 X-Forwarded-Proto 获取（http/https/quic）
+ * - 主机通过 Host 头获取
+ */
+
+import type { Context, Next } from 'koa';
+import { setKVBaseUrl } from '../shared/kv-client.js';
+
+/**
+ * 从请求上下文中提取 baseUrl
+ * 支持 EdgeOne 和其他部署环境
+ */
+export function extractBaseUrl(ctx: Context): string {
+  // 优先使用环境变量（本地开发或显式配置）
+  const envUrl = process.env.KV_BASE_URL;
+  if (envUrl && envUrl.trim()) {
+    return envUrl.trim();
+  }
+
+  // 自动检测协议
+  // EdgeOne 默认携带 X-Forwarded-Proto 头（http/https/quic）
+  // 优先级：x-forwarded-proto > x-scheme > protocol > https
+  let protocol = 
+    ctx.get('x-forwarded-proto') || 
+    ctx.get('x-scheme') || 
+    ctx.protocol || 
+    'https';
+  
+  // 如果是 quic，转换为 https
+  if (protocol === 'quic') {
+    protocol = 'https';
+  }
+
+  // 自动检测主机
+  // EdgeOne 环境下使用 Host 头
+  // 优先级：x-forwarded-host > host > localhost:8088
+  const host = 
+    ctx.get('x-forwarded-host') || 
+    ctx.get('host') || 
+    'localhost:8088';
+
+  const baseUrl = `${protocol}://${host}`;
+  
+  return baseUrl;
+}
+
+/**
+ * KV Base URL 中间件
+ * 在每个请求开始时设置 KV API 的 baseUrl
+ */
+export async function kvBaseUrlMiddleware(ctx: Context, next: Next): Promise<void> {
+  const baseUrl = extractBaseUrl(ctx);
+  setKVBaseUrl(baseUrl);
+  
+  // 调试日志（仅在开发环境或启用调试时）
+  if (process.env.NODE_ENV === 'development' || process.env.DEBUG_KV_URL === 'true') {
+    console.log('\x1b[35m[KV]\x1b[0m Base URL:', baseUrl);
+    console.log('\x1b[35m[KV]\x1b[0m Headers:', {
+      'x-forwarded-proto': ctx.get('x-forwarded-proto'),
+      'x-forwarded-host': ctx.get('x-forwarded-host'),
+      'host': ctx.get('host'),
+      'protocol': ctx.protocol,
+    });
+  }
+  
+  await next();
+}

--- a/node-functions/send/[[key]].ts
+++ b/node-functions/send/[[key]].ts
@@ -14,7 +14,7 @@ import Koa from 'koa';
 // @ts-ignore - koa-bodyparser types are not fully compatible
 import bodyParser from 'koa-bodyparser';
 import { pushService } from '../services/push.service.js';
-import { setKVBaseUrl } from '../shared/kv-client.js';
+import { kvBaseUrlMiddleware } from '../middleware/index.js';
 import { ErrorCodes } from '../types/index.js';
 import type { PushMessageInput } from '../types/index.js';
 
@@ -37,21 +37,8 @@ app.use(async (ctx, next) => {
 // Body parser
 app.use(bodyParser());
 
-// 设置 KV baseUrl
-// 优先使用环境变量 KV_BASE_URL，生产环境留空使用同源
-app.use(async (ctx, next) => {
-  const kvBaseUrl = process.env.KV_BASE_URL;
-  
-  if (kvBaseUrl) {
-    setKVBaseUrl(kvBaseUrl);
-  } else {
-    const protocol = ctx.get('x-forwarded-proto') || ctx.protocol || 'http';
-    const host = ctx.get('host') || 'localhost:8088';
-    setKVBaseUrl(`${protocol}://${host}`);
-  }
-  
-  await next();
-});
+// KV Base URL 中间件
+app.use(kvBaseUrlMiddleware);
 
 // 主处理逻辑
 app.use(async (ctx) => {

--- a/node-functions/shared/kv-client.ts
+++ b/node-functions/shared/kv-client.ts
@@ -29,10 +29,18 @@ export function setKVBaseUrl(url: string): void {
 
 /**
  * Get the base URL for KV API
- * 优先使用环境变量 KV_BASE_URL，其次使用动态设置的 baseUrl
+ * 优先级：环境变量 KV_BASE_URL > 动态设置的 baseUrl > 空字符串（同源请求）
  */
 function getBaseUrl(): string {
-  return process.env.KV_BASE_URL || dynamicBaseUrl || '';
+  const envUrl = process.env.KV_BASE_URL;
+  
+  // 如果环境变量存在且不为空，使用环境变量
+  if (envUrl && envUrl.trim()) {
+    return envUrl.trim();
+  }
+  
+  // 否则使用动态设置的 baseUrl（从请求上下文中获取）
+  return dynamicBaseUrl || '';
 }
 
 /**


### PR DESCRIPTION
- Create new `kv-base-url.ts` middleware with `kvBaseUrlMiddleware` and `extractBaseUrl` functions
- Extract KV base URL detection logic from `send/[[key]].ts` and `v1/[[default]].ts` into centralized middleware
- Implement automatic domain detection from request headers with priority: env variable > x-forwarded-proto/host > protocol/host > defaults
- Add support for EdgeOne environment with X-Forwarded-Proto and X-Forwarded-Host headers
- Handle QUIC protocol conversion to HTTPS for proper URL construction
- Add debug logging for KV URL configuration in development mode
- Update `middleware/index.ts` to export new middleware functions
- Improve `kv-client.ts` getBaseUrl() with better environment variable handling and trimming
- Add comprehensive documentation in `LOCAL_DEVELOPMENT.md` explaining KV_BASE_URL configuration for local and production environments
- Consolidates duplicate middleware logic and improves maintainability across multiple entry points