### PR TITLE
refactor(kv-client): simplify base URL extraction and improve cleanup…

### DIFF
--- a/node-functions/routes/demo-apps.ts
+++ b/node-functions/routes/demo-apps.ts
@@ -13,6 +13,7 @@ import { appService } from '../services/app.service.js';
 import { bindCodeService } from '../services/bindcode.service.js';
 import { channelService } from '../services/channel.service.js';
 import { cleanupService } from '../services/cleanup.service.js';
+import { extractBaseUrl } from '../middleware/kv-base-url.js';
 import { ApiError } from '../types/index.js';
 import type { PushMode, MessageType } from '../types/app.js';
 
@@ -52,8 +53,9 @@ function calculateDaysRemaining(createdAt?: string): number {
  * @returns {App[]} 体验应用列表
  */
 router.get('/', async (ctx: AppContext) => {
-  // 触发清理任务
-  cleanupService.triggerCleanup().catch(console.error);
+  // 触发清理任务（传递 baseUrl）
+  const baseUrl = extractBaseUrl(ctx);
+  cleanupService.triggerCleanup(baseUrl).catch(console.error);
 
   const apps = await demoAppService.list();
 
@@ -83,8 +85,9 @@ router.get('/', async (ctx: AppContext) => {
  * @returns {App} 创建的体验应用信息
  */
 router.post('/', async (ctx: AppContext) => {
-  // 触发清理任务
-  cleanupService.triggerCleanup().catch(console.error);
+  // 触发清理任务（传递 baseUrl）
+  const baseUrl = extractBaseUrl(ctx);
+  cleanupService.triggerCleanup(baseUrl).catch(console.error);
 
   const body = ctx.request.body as { name: string; pushMode: PushMode; messageType?: MessageType } | undefined;
 

--- a/node-functions/send/[[key]].ts
+++ b/node-functions/send/[[key]].ts
@@ -20,6 +20,9 @@ import type { PushMessageInput } from '../types/index.js';
 
 const app = new Koa();
 
+// 信任代理（EdgeOne 环境必需）
+app.proxy = true;
+
 // CORS 中间件
 app.use(async (ctx, next) => {
   ctx.set('Access-Control-Allow-Origin', '*');

--- a/node-functions/services/cleanup.service.ts
+++ b/node-functions/services/cleanup.service.ts
@@ -5,6 +5,8 @@
  * 负责定期清理过期的体验应用，使用防抖机制避免频繁执行
  */
 
+import { runKVOperation } from '../shared/kv-client.js';
+
 class CleanupService {
   private lastCleanupTime: number = 0;
   private readonly CLEANUP_INTERVAL = 60 * 60 * 1000; // 1小时
@@ -14,8 +16,10 @@ class CleanupService {
    * 
    * 防抖机制：1小时内只执行一次清理任务
    * 这样可以避免频繁的清理操作影响性能
+   * 
+   * @param baseUrl - KV API 的 base URL（从请求上下文传入）
    */
-  async triggerCleanup(): Promise<void> {
+  async triggerCleanup(baseUrl?: string): Promise<void> {
     const now = Date.now();
 
     // 防抖：1小时内只执行一次
@@ -23,18 +27,37 @@ class CleanupService {
       return;
     }
 
+    console.log('\x1b[36m[CleanupService]\x1b[0m Starting cleanup with baseUrl:', baseUrl || '(using env)');
+
     try {
-      // 动态导入避免循环依赖
-      const { demoAppService } = await import('./demo-app.service.js');
-      const count = await demoAppService.cleanupExpired();
+      // 如果提供了 baseUrl，在其上下文中运行清理任务
+      if (baseUrl) {
+        await runKVOperation(baseUrl, async () => {
+          await this.executeCleanup();
+        });
+      } else {
+        // 否则直接运行（依赖环境变量）
+        await this.executeCleanup();
+      }
       
       // 只有清理成功才更新时间戳
       this.lastCleanupTime = now;
-      console.log(`[CleanupService] Cleaned up ${count} expired demo apps`);
     } catch (error) {
       console.error('[CleanupService] Cleanup failed:', error);
+      console.error('[CleanupService] baseUrl was:', baseUrl || '(not provided)');
+      console.error('[CleanupService] KV_BASE_URL env:', process.env.KV_BASE_URL || '(not set)');
       // 清理失败时不更新时间戳，允许下次重试
     }
+  }
+
+  /**
+   * 执行清理任务
+   */
+  private async executeCleanup(): Promise<void> {
+    // 动态导入避免循环依赖
+    const { demoAppService } = await import('./demo-app.service.js');
+    const count = await demoAppService.cleanupExpired();
+    console.log(`[CleanupService] Cleaned up ${count} expired demo apps`);
   }
 
   /**

--- a/node-functions/v1/[[default]].ts
+++ b/node-functions/v1/[[default]].ts
@@ -32,6 +32,9 @@ import {
 
 const app = new Koa();
 
+// 信任代理（EdgeOne 环境必需）
+app.proxy = true;
+
 // 错误处理中间件（最外层）
 app.use(errorHandler);
 


### PR DESCRIPTION
… service integration

- Simplify extractBaseUrl() to use ctx.origin instead of manual protocol/host detection
- Add app.proxy = true to send endpoint for proper EdgeOne proxy header handling
- Pass baseUrl parameter to cleanupService.triggerCleanup() from request context
- Implement runKVOperation() wrapper to execute cleanup within correct KV context
- Extract executeCleanup() as private method to support context-aware execution
- Add comprehensive debug logging for base URL extraction and middleware flow
- Improve error logging with baseUrl and KV_BASE_URL environment variable details
- Ensure cleanup tasks use correct base URL from incoming requests instead of stale env vars