### PR TITLE
fix(middleware): handle null ctx.origin and add app.proxy validation

### DIFF
--- a/node-functions/middleware/kv-base-url.ts
+++ b/node-functions/middleware/kv-base-url.ts
@@ -25,12 +25,37 @@ export function extractBaseUrl(ctx: Context): string {
     return envUrl.trim();
   }
 
-  // 使用 Koa 的 ctx.origin（包含 protocol 和 host）
+  // 尝试使用 Koa 的 ctx.origin（包含 protocol 和 host）
   // ctx.origin 会自动处理代理头（当 app.proxy = true 时）
-  const origin = ctx.origin;
+  let origin = ctx.origin;
   
-  console.log('\x1b[35m[KV Extract]\x1b[0m Using ctx.origin:', origin);
-  console.log('\x1b[35m[KV Extract]\x1b[0m app.proxy should be true for EdgeOne');
+  // 如果 ctx.origin 为 null，手动构建
+  if (!origin || origin === 'null') {
+    console.log('\x1b[33m[KV Extract]\x1b[0m ctx.origin is null, building manually');
+    
+    // 手动从请求头构建 origin
+    const protocol = ctx.get('x-forwarded-proto') || ctx.protocol || 'https';
+    const host = ctx.get('x-forwarded-host') || ctx.get('host') || ctx.host;
+    
+    if (host) {
+      origin = `${protocol}://${host}`;
+      console.log('\x1b[33m[KV Extract]\x1b[0m Manually built origin:', origin);
+    } else {
+      console.error('\x1b[31m[KV Extract]\x1b[0m Cannot determine host!');
+      console.error('\x1b[31m[KV Extract]\x1b[0m Headers:', {
+        'x-forwarded-proto': ctx.get('x-forwarded-proto'),
+        'x-forwarded-host': ctx.get('x-forwarded-host'),
+        'host': ctx.get('host'),
+        'ctx.host': ctx.host,
+        'ctx.hostname': ctx.hostname,
+      });
+      // 返回空字符串会导致相对路径，这会失败
+      // 但至少我们能看到错误日志
+      return '';
+    }
+  } else {
+    console.log('\x1b[35m[KV Extract]\x1b[0m Using ctx.origin:', origin);
+  }
   
   // 详细调试日志
   if (process.env.DEBUG_KV_URL === 'true') {
@@ -52,6 +77,13 @@ export function extractBaseUrl(ctx: Context): string {
  * 在每个请求开始时设置 KV API 的 baseUrl
  */
 export async function kvBaseUrlMiddleware(ctx: Context, next: Next): Promise<void> {
+  // 检查 app.proxy 设置
+  const app = ctx.app as any;
+  if (!app.proxy) {
+    console.error('\x1b[31m[KV Middleware]\x1b[0m WARNING: app.proxy is not set to true!');
+    console.error('\x1b[31m[KV Middleware]\x1b[0m This will cause ctx.origin to be null in proxy environments');
+  }
+  
   const baseUrl = extractBaseUrl(ctx);
   
   // 总是打印 baseUrl（用于调试）

--- a/node-functions/send/[[key]].ts
+++ b/node-functions/send/[[key]].ts
@@ -23,6 +23,9 @@ const app = new Koa();
 // 信任代理（EdgeOne 环境必需）
 app.proxy = true;
 
+// 验证 app.proxy 设置
+console.log('\x1b[36m[Send Init]\x1b[0m app.proxy is set to:', app.proxy);
+
 // CORS 中间件
 app.use(async (ctx, next) => {
   ctx.set('Access-Control-Allow-Origin', '*');

--- a/node-functions/v1/[[default]].ts
+++ b/node-functions/v1/[[default]].ts
@@ -35,6 +35,9 @@ const app = new Koa();
 // 信任代理（EdgeOne 环境必需）
 app.proxy = true;
 
+// 验证 app.proxy 设置
+console.log('\x1b[36m[App Init]\x1b[0m app.proxy is set to:', app.proxy);
+
 // 错误处理中间件（最外层）
 app.use(errorHandler);
 


### PR DESCRIPTION
- Add fallback logic to manually construct origin from request headers when ctx.origin is null
- Extract protocol from x-forwarded-proto header with https as default
- Extract host from x-forwarded-host or host headers as fallback
- Add validation check for app.proxy setting in kvBaseUrlMiddleware
- Log warning when app.proxy is not enabled to help diagnose proxy environment issues
- Add initialization logging in send and v1 endpoints to verify app.proxy configuration
- Improve error diagnostics by logging all relevant headers when host cannot be determined
- Prevents baseUrl extraction failures in proxy environments where ctx.origin may be null